### PR TITLE
roughnessMetallicTexture to metallicRoughnessTexture

### DIFF
--- a/extensions/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
+++ b/extensions/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
@@ -37,7 +37,7 @@ The example below shows how this extension can be used along with the MSFT_textu
                 "baseColorTexture": {
                     "index": 0
                 },
-                "roughnessMetallicTexture": {
+                "metallicRoughnessTexture": {
                 "index": 1
                 },
             },
@@ -70,7 +70,7 @@ The example below shows how this extension can be used along with the MSFT_textu
             }
         },
         {
-            "name":"roughnessMetallicTexture",
+            "name":"metallicRoughnessTexture",
             "source":1
         },
         {


### PR DESCRIPTION
The material attribute is called metallicRoughnessTexture, not roughnessMetallicTexture. Otherwise, even the Microsoft Mixed Reality Viewer will ignore it.